### PR TITLE
Review ANSI row IR follow-up fixes

### DIFF
--- a/cpp/include/cudf/operators/ansi_arithmetic.cuh
+++ b/cpp/include/cudf/operators/ansi_arithmetic.cuh
@@ -311,9 +311,7 @@ template <typename T>
 __device__ inline errc ansi_mod(T* out, T const* a, T const* b)
 {
   if (*b == 0) { return errc::DIVISION_BY_ZERO; }
-  T r = *a % *b;
-  if (r != 0 && ((r > 0) != (*b > 0))) { r += *b; }
-  *out = r;
+  *out = *a % *b;
   return errc::OK;
 }
 
@@ -329,14 +327,14 @@ __device__ inline errc ansi_mod(T* out, T const* a, T const* b)
 __device__ inline errc ansi_mod(float* out, float const* a, float const* b)
 {
   if (*b == 0) { return errc::DIVISION_BY_ZERO; }
-  *out = (*a) - (*b) * ::floorf((*a) / (*b));
+  *out = ::fmodf(*a, *b);
   return errc::OK;
 }
 
 __device__ inline errc ansi_mod(double* out, double const* a, double const* b)
 {
   if (*b == 0) { return errc::DIVISION_BY_ZERO; }
-  *out = (*a) - (*b) * ::floor((*a) / (*b));
+  *out = ::fmod(*a, *b);
   return errc::OK;
 }
 
@@ -350,7 +348,11 @@ __device__ inline errc ansi_mod(decimal<R>* out, decimal<R> const* a, decimal<R>
   if (errc e = ansi_div(&div, a, b); e != errc::OK) { return e; }
 
   decimal<R> quotient;
-  floor(&quotient, &div);
+  if (div.value() < 0) {
+    ceil(&quotient, &div);
+  } else {
+    floor(&quotient, &div);
+  }
   *out = *a - *b * quotient;
   return errc::OK;
 }

--- a/cpp/include/cudf/operators/casts.cuh
+++ b/cpp/include/cudf/operators/casts.cuh
@@ -333,7 +333,8 @@ __device__ inline errc rescale(optional<decimal<R>>* out,
 {
   if (a->has_value() && new_scale->has_value()) {
     decimal<R> r;
-    rescale(&r, &a->value(), new_scale->value());
+    auto const scale = new_scale->value();
+    rescale(&r, &a->value(), &scale);
     *out = r;
   } else {
     *out = nullopt;

--- a/cpp/include/cudf/operators/logic.cuh
+++ b/cpp/include/cudf/operators/logic.cuh
@@ -139,7 +139,7 @@ __device__ inline errc if_else(optional<T>* out,
                                optional<bool> const* pred)
 {
   if (pred->has_value() && true_value->has_value() && false_value->has_value()) {
-    if_else<T>(&out->value(), &pred->value(), &true_value->value(), &false_value->value());
+    if_else<T>(&out->value(), &true_value->value(), &false_value->value(), &pred->value());
   } else {
     *out = nullopt;
   }

--- a/cpp/include/cudf/operators/logic.cuh
+++ b/cpp/include/cudf/operators/logic.cuh
@@ -138,8 +138,13 @@ __device__ inline errc if_else(optional<T>* out,
                                optional<T> const* false_value,
                                optional<bool> const* pred)
 {
-  if (pred->has_value() && true_value->has_value() && false_value->has_value()) {
-    if_else<T>(&out->value(), &true_value->value(), &false_value->value(), &pred->value());
+  if (pred->has_value()) {
+    auto const* value = pred->value() ? true_value : false_value;
+    if (value->has_value()) {
+      *out = value->value();
+    } else {
+      *out = nullopt;
+    }
   } else {
     *out = nullopt;
   }

--- a/cpp/src/jit/helpers.cpp
+++ b/cpp/src/jit/helpers.cpp
@@ -9,8 +9,18 @@
 
 #include <jit/cache.hpp>
 
+#include <string>
+
 namespace cudf {
 namespace jit {
+namespace {
+
+bool is_jitify_deserialization_failure(jitify2::Kernel const& kernel)
+{
+  return !kernel && kernel.error().find("Deserialization failed") != std::string::npos;
+}
+
+}  // namespace
 
 bool is_scalar(cudf::size_type base_column_size, cudf::size_type column_size)
 {
@@ -111,8 +121,18 @@ jitify2::Kernel get_udf_kernel(jitify2::PreprocessedProgramData const& preproces
     options.push_back(opt);
   }
 
-  return cudf::jit::get_program_cache(preprocessed_program_data)
-    .get_kernel(kernel_name, {}, {{"cudf/detail/operation-udf.hpp", cuda_source}}, options);
+  auto& cache = cudf::jit::get_program_cache(preprocessed_program_data);
+  auto const get_kernel = [&] {
+    return cache.get_kernel(
+      kernel_name, {}, {{"cudf/detail/operation-udf.hpp", cuda_source}}, options);
+  };
+
+  auto kernel = get_kernel();
+  if (is_jitify_deserialization_failure(kernel)) {
+    // Corrupt file-cache entries otherwise poison all later runs until manual cleanup.
+    if (cache.clear()) { kernel = get_kernel(); }
+  }
+  return kernel;
 }
 
 }  // namespace jit

--- a/cpp/src/transform/jit/kernel.cu
+++ b/cpp/src/transform/jit/kernel.cu
@@ -46,29 +46,35 @@ namespace cudf {
 namespace jit {
 
 template <ops::error_mode mode, bool has_user_data, typename Args>
-__device__ void execute_transform_op(error_sink* __restrict__ error_sink,
+__device__ bool execute_transform_op(error_sink* __restrict__ error_sink,
                                      void* user_data,
                                      size_type element_idx,
                                      Args args)
 {
   // TODO: static assert invocable
   if constexpr (has_user_data) {
-    cuda::std::apply(
+    return cuda::std::apply(
       [&](auto... a) {
         if constexpr (mode == ops::error_mode::IGNORE) {
           GENERIC_TRANSFORM_OP(a...);
+          return true;
         } else {
-          error_sink->report<mode>(GENERIC_TRANSFORM_OP(a...));
+          auto const error = GENERIC_TRANSFORM_OP(a...);
+          error_sink->report<mode>(error);
+          return error == ops::errc::OK;
         }
       },
       cuda::std::tuple_cat(cuda::std::tuple{user_data, element_idx}, args));
   } else {
-    cuda::std::apply(
+    return cuda::std::apply(
       [&](auto... a) {
         if constexpr (mode == ops::error_mode::IGNORE) {
           GENERIC_TRANSFORM_OP(a...);
+          return true;
         } else {
-          error_sink->report<mode>(GENERIC_TRANSFORM_OP(a...));
+          auto const error = GENERIC_TRANSFORM_OP(a...);
+          error_sink->report<mode>(error);
+          return error == ops::errc::OK;
         }
       },
       args);
@@ -106,8 +112,9 @@ CUDF_KERNEL void transform_kernel(size_type row_size,
       auto out_ptrs =
         cuda::std::apply([&](auto&... args) { return cuda::std::tuple{&args...}; }, outs);
 
-      execute_transform_op<error_mode, has_user_data>(
+      auto const success = execute_transform_op<error_mode, has_user_data>(
         error_sink, user_data, element_idx, cuda::std::tuple_cat(out_ptrs, ins));
+      if (!success) { continue; }
 
       OutputAccessors::map([&]<typename... A>() {
         (A::assign(output_cols, element_idx, cuda::std::get<A::index>(outs)), ...);
@@ -127,13 +134,18 @@ CUDF_KERNEL void transform_kernel(size_type row_size,
       auto out_ptrs =
         cuda::std::apply([&](auto&... args) { return cuda::std::tuple{&args...}; }, outs);
 
-      execute_transform_op<error_mode, has_user_data>(
+      auto const success = execute_transform_op<error_mode, has_user_data>(
         error_sink, user_data, element_idx, cuda::std::tuple_cat(out_ptrs, ins));
 
       OutputAccessors::map([&]<typename... A>() {
-        (A::assign(output_cols, element_idx, *cuda::std::get<A::index>(outs)), ...);
+        if (success) {
+          (A::assign(output_cols, element_idx, *cuda::std::get<A::index>(outs)), ...);
+        }
         (warp_compact_validity<A>(
-           active_mask, output_cols, element_idx, cuda::std::get<A::index>(outs).has_value()),
+           active_mask,
+           output_cols,
+           element_idx,
+           success && cuda::std::get<A::index>(outs).has_value()),
          ...);
       });
     }

--- a/cpp/src/transform/transform.cu
+++ b/cpp/src/transform/transform.cu
@@ -802,6 +802,25 @@ auto finalize_outputs(null_aware is_null_aware,
   return results;
 }
 
+void check_transform_error(ops::error_mode error_handling_mode,
+                           std::optional<rmm::device_scalar<jit::error_sink>> const& d_error_sink,
+                           rmm::cuda_stream_view stream)
+{
+  switch (error_handling_mode) {
+    case ops::error_mode::IGNORE: break;
+    case ops::error_mode::ANY_ROW: {
+      auto error = d_error_sink->value(stream).any_error();
+      switch (error) {
+        case ops::errc::OK: break;
+        case ops::errc::OVERFLOW: CUDF_FAIL("Overflow error in transform UDF", std::overflow_error);
+        case ops::errc::DIVISION_BY_ZERO:
+          CUDF_FAIL("Division by zero error in transform UDF", std::overflow_error);
+        default: CUDF_FAIL("Unknown error in transform UDF", std::runtime_error);
+      }
+    } break;
+  }
+}
+
 std::unique_ptr<table> execute_transform(std::string const& udf,
                                          udf_source_type source_type,
                                          ops::error_mode error_handling_mode,
@@ -851,22 +870,9 @@ std::unique_ptr<table> execute_transform(std::string const& udf,
                      stream,
                      mr);
 
-  auto finalized = finalize_outputs(is_null_aware, row_size, std::move(output_columns), stream, mr);
+  check_transform_error(error_handling_mode, d_error_sink, stream);
 
-  switch (error_handling_mode) {
-    case ops::error_mode::IGNORE: {
-    } break;
-    case ops::error_mode::ANY_ROW: {
-      auto error = d_error_sink->value(stream).any_error();
-      switch (error) {
-        case ops::errc::OK: break;
-        case ops::errc::OVERFLOW: CUDF_FAIL("Overflow error in transform UDF", std::overflow_error);
-        case ops::errc::DIVISION_BY_ZERO:
-          CUDF_FAIL("Division by zero error in transform UDF", std::overflow_error);
-        default: CUDF_FAIL("Unknown error in transform UDF", std::runtime_error);
-      }
-    } break;
-  }
+  auto finalized = finalize_outputs(is_null_aware, row_size, std::move(output_columns), stream, mr);
 
   return std::make_unique<table>(std::move(finalized));
 }

--- a/cpp/tests/ast/jit_ast_tests.cpp
+++ b/cpp/tests/ast/jit_ast_tests.cpp
@@ -48,12 +48,16 @@ template <typename T>
 struct JITSignedIntegerArithmeticTest : public JITIntegerArithmeticTest<T> {};
 
 template <typename T>
+struct JITFloatingPointArithmeticTest : public cudf::test::BaseFixture {};
+
+template <typename T>
 struct JITDecimalArithmeticTest : public JITIntegerArithmeticTest<typename T::rep> {};
 
 using SignedIntegralTypesNotBool = cudf::test::Types<int8_t, int16_t, int32_t, int64_t>;
 
 TYPED_TEST_SUITE(JITIntegerArithmeticTest, cudf::test::IntegralTypesNotBool);
 TYPED_TEST_SUITE(JITSignedIntegerArithmeticTest, SignedIntegralTypesNotBool);
+TYPED_TEST_SUITE(JITFloatingPointArithmeticTest, cudf::test::FloatingPointTypes);
 TYPED_TEST_SUITE(JITDecimalArithmeticTest, cudf::test::FixedPointTypes);
 
 TEST_F(JITExpressionTest, NullifyIf)
@@ -330,15 +334,58 @@ TYPED_TEST(JITIntegerArithmeticTest, AnsiMod)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_fail, result_fail->view(), VERBOSITY);
 }
 
+TYPED_TEST(JITSignedIntegerArithmeticTest, AnsiModSignedRemainder)
+{
+  using T       = TypeParam;
+  auto a        = column_wrapper<T>{{T{-5}, T{5}, T{-5}, T{5}}};
+  auto b        = column_wrapper<T>{{T{3}, T{-3}, T{-3}, T{3}}};
+  auto expected = column_wrapper<T>{{T{-2}, T{2}, T{-2}, T{2}}};
+  auto table    = cudf::table_view{{a, b}};
+  auto a_ref    = cudf::ast::column_reference(0);
+  auto b_ref    = cudf::ast::column_reference(1);
+  auto tree     = cudf::ast::tree{};
+  auto& mod     = cudf::ast::jit::ansi_mod(tree, a_ref, b_ref);
+  auto result   = cudf::compute_column_jit(table, mod);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), VERBOSITY);
+}
+
+TYPED_TEST(JITFloatingPointArithmeticTest, AnsiMod)
+{
+  using T            = TypeParam;
+  auto a             = column_wrapper<T>{{T{3.0}, T{20.0}, T{-5.5}, T{5.5}, T{-5.5}}};
+  auto b             = column_wrapper<T>{{T{10.0}, T{7.0}, T{2.0}, T{-2.0}, T{-2.0}}};
+  auto b_fail        = column_wrapper<T>{{T{10.0}, T{0.0}, T{2.0}, T{0.0}, T{-2.0}}};
+  auto expected      = column_wrapper<T>{{T{3.0}, T{6.0}, T{-1.5}, T{1.5}, T{-1.5}}};
+  auto expected_fail = column_wrapper<T>{
+    {T{3.0}, T{0.0}, T{-1.5}, T{0.0}, T{-1.5}}, {1, 0, 1, 0, 1}};
+  auto table         = cudf::table_view{{a, b, b_fail}};
+  auto a_ref         = cudf::ast::column_reference(0);
+  auto b_ref         = cudf::ast::column_reference(1);
+  auto b_fail_ref    = cudf::ast::column_reference(2);
+  auto tree          = cudf::ast::tree{};
+  auto& mod          = cudf::ast::jit::ansi_mod(tree, a_ref, b_ref);
+  auto& mod_fail     = cudf::ast::jit::ansi_mod(tree, a_ref, b_fail_ref);
+  auto& try_mod_fail = cudf::ast::jit::ansi_try_mod(tree, a_ref, b_fail_ref);
+  auto result        = cudf::compute_column_jit(table, mod);
+  auto result_fail   = cudf::compute_column_jit(table, try_mod_fail);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected, result->view(), VERBOSITY);
+
+  EXPECT_THROW(result = cudf::compute_column_jit(table, mod_fail), std::overflow_error);
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(expected_fail, result_fail->view(), VERBOSITY);
+}
+
 TYPED_TEST(JITDecimalArithmeticTest, AnsiMod)
 {
   using T       = TypeParam;
-  auto a        = decimal_column_wrapper<T>{{3, 20, 1, 50}, numeric::scale_type{0}};
-  auto b        = decimal_column_wrapper<T>{{10, 7, 2, 1}, numeric::scale_type{0}};
-  auto b_fail   = decimal_column_wrapper<T>{{10, 1, 20, 0}, numeric::scale_type{0}};
-  auto expected = decimal_column_wrapper<T>{{3, 6, 1, 0}, numeric::scale_type{0}};
+  auto a        = decimal_column_wrapper<T>{{3, 20, 1, 50, -5, 5, -5}, numeric::scale_type{0}};
+  auto b        = decimal_column_wrapper<T>{{10, 7, 2, 1, 3, -3, -3}, numeric::scale_type{0}};
+  auto b_fail   = decimal_column_wrapper<T>{{10, 1, 20, 0, 1, 1, 1}, numeric::scale_type{0}};
+  auto expected = decimal_column_wrapper<T>{{3, 6, 1, 0, -2, 2, -2}, numeric::scale_type{0}};
   auto expected_fail =
-    decimal_column_wrapper<T>{{3, 0, 1, 0}, {1, 1, 1, 0}, numeric::scale_type{0}};
+    decimal_column_wrapper<T>{{3, 0, 1, 0, 0, 0, 0}, {1, 1, 1, 0, 1, 1, 1}, numeric::scale_type{0}};
   auto table         = cudf::table_view{{a, b, b_fail}};
   auto a_ref         = cudf::ast::column_reference(0);
   auto b_ref         = cudf::ast::column_reference(1);

--- a/java/src/main/java/ai/rapids/cudf/ast/JitOperation.java
+++ b/java/src/main/java/ai/rapids/cudf/ast/JitOperation.java
@@ -12,10 +12,20 @@ import java.util.Objects;
 public final class JitOperation extends AstExpression {
   private final JitOperator op;
   private final AstExpression[] inputs;
+  private final Integer targetScale;
 
   public JitOperation(JitOperator op, AstExpression... inputs) {
+    this(op, null, inputs);
+  }
+
+  public JitOperation(JitOperator op, int targetScale, AstExpression... inputs) {
+    this(op, Integer.valueOf(targetScale), inputs);
+  }
+
+  private JitOperation(JitOperator op, Integer targetScale, AstExpression... inputs) {
     this.op = Objects.requireNonNull(op, "op is null");
     this.inputs = Objects.requireNonNull(inputs, "inputs is null").clone();
+    this.targetScale = targetScale;
     if (this.inputs.length != op.getArity()) {
       throw new IllegalArgumentException(
           op + " requires " + op.getArity() + " inputs, found " + this.inputs.length);
@@ -30,6 +40,10 @@ public final class JitOperation extends AstExpression {
     int size = ExpressionType.JIT_EXPRESSION.getSerializedSize() +
         op.getSerializedSize() +
         Byte.BYTES;
+    size += Byte.BYTES;
+    if (targetScale != null) {
+      size += Integer.BYTES;
+    }
     for (AstExpression input : inputs) {
       size += input.getSerializedSize();
     }
@@ -41,6 +55,10 @@ public final class JitOperation extends AstExpression {
     ExpressionType.JIT_EXPRESSION.serialize(bb);
     op.serialize(bb);
     bb.put((byte) inputs.length);
+    bb.put((byte) (targetScale == null ? 0 : 1));
+    if (targetScale != null) {
+      bb.putInt(targetScale);
+    }
     for (AstExpression input : inputs) {
       input.serialize(bb);
     }

--- a/java/src/main/java/ai/rapids/cudf/ast/JitOperator.java
+++ b/java/src/main/java/ai/rapids/cudf/ast/JitOperator.java
@@ -21,7 +21,13 @@ public enum JitOperator {
   BIT_SHIFT_RIGHT(6, 2),
   COALESCE(7, 2),
   NULLIFY_IF(8, 2),
-  PREDICATE(9, 1);
+  PREDICATE(9, 1),
+  ANSI_PRECISION_CHECK(10, 2),
+  ANSI_TRY_PRECISION_CHECK(11, 2),
+  CAST_TO_DEC32(12, 1),
+  CAST_TO_DEC64(13, 1),
+  CAST_TO_DEC128(14, 1),
+  RESCALE(15, 1);
 
   private final byte nativeId;
   private final int arity;

--- a/java/src/main/java/ai/rapids/cudf/ast/JitOperator.java
+++ b/java/src/main/java/ai/rapids/cudf/ast/JitOperator.java
@@ -27,7 +27,28 @@ public enum JitOperator {
   CAST_TO_DEC32(12, 1),
   CAST_TO_DEC64(13, 1),
   CAST_TO_DEC128(14, 1),
-  RESCALE(15, 1);
+  RESCALE(15, 1),
+  ANSI_DIV(16, 2),
+  ANSI_MOD(17, 2),
+  CAST_TO_I64(18, 1),
+  ANSI_TRY_ADD(19, 2),
+  ANSI_TRY_SUB(20, 2),
+  ANSI_TRY_MUL(21, 2),
+  ANSI_TRY_DIV(22, 2),
+  ANSI_TRY_MOD(23, 2),
+  ANSI_TRY_ABS(24, 1),
+  ANSI_TRY_NEG(25, 1),
+  CAST_TO_B8(26, 1),
+  CAST_TO_I8(27, 1),
+  CAST_TO_I16(28, 1),
+  CAST_TO_I32(29, 1),
+  CAST_TO_U8(30, 1),
+  CAST_TO_U16(31, 1),
+  CAST_TO_U32(32, 1),
+  CAST_TO_U64(33, 1),
+  CAST_TO_F32(34, 1),
+  CAST_TO_F64(35, 1),
+  IF_ELSE(36, 3);
 
   private final byte nativeId;
   private final int arity;

--- a/java/src/main/native/src/CompiledExpression.cpp
+++ b/java/src/main/native/src/CompiledExpression.cpp
@@ -221,6 +221,27 @@ cudf::detail::row_ir::opcode jni_to_jit_operator(jbyte jni_op_value)
     case 13: return cudf::detail::row_ir::opcode::CAST_TO_DEC64;
     case 14: return cudf::detail::row_ir::opcode::CAST_TO_DEC128;
     case 15: return cudf::detail::row_ir::opcode::RESCALE;
+    case 16: return cudf::detail::row_ir::opcode::ANSI_DIV;
+    case 17: return cudf::detail::row_ir::opcode::ANSI_MOD;
+    case 18: return cudf::detail::row_ir::opcode::CAST_TO_I64;
+    case 19: return cudf::detail::row_ir::opcode::ANSI_TRY_ADD;
+    case 20: return cudf::detail::row_ir::opcode::ANSI_TRY_SUB;
+    case 21: return cudf::detail::row_ir::opcode::ANSI_TRY_MUL;
+    case 22: return cudf::detail::row_ir::opcode::ANSI_TRY_DIV;
+    case 23: return cudf::detail::row_ir::opcode::ANSI_TRY_MOD;
+    case 24: return cudf::detail::row_ir::opcode::ANSI_TRY_ABS;
+    case 25: return cudf::detail::row_ir::opcode::ANSI_TRY_NEG;
+    case 26: return cudf::detail::row_ir::opcode::CAST_TO_B8;
+    case 27: return cudf::detail::row_ir::opcode::CAST_TO_I8;
+    case 28: return cudf::detail::row_ir::opcode::CAST_TO_I16;
+    case 29: return cudf::detail::row_ir::opcode::CAST_TO_I32;
+    case 30: return cudf::detail::row_ir::opcode::CAST_TO_U8;
+    case 31: return cudf::detail::row_ir::opcode::CAST_TO_U16;
+    case 32: return cudf::detail::row_ir::opcode::CAST_TO_U32;
+    case 33: return cudf::detail::row_ir::opcode::CAST_TO_U64;
+    case 34: return cudf::detail::row_ir::opcode::CAST_TO_F32;
+    case 35: return cudf::detail::row_ir::opcode::CAST_TO_F64;
+    case 36: return cudf::detail::row_ir::opcode::IF_ELSE;
     default: throw std::invalid_argument("unexpected JNI AST JIT operator value");
   }
 }

--- a/java/src/main/native/src/CompiledExpression.cpp
+++ b/java/src/main/native/src/CompiledExpression.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 
@@ -214,6 +215,12 @@ cudf::detail::row_ir::opcode jni_to_jit_operator(jbyte jni_op_value)
     case 7: return cudf::detail::row_ir::opcode::COALESCE;
     case 8: return cudf::detail::row_ir::opcode::NULLIFY_IF;
     case 9: return cudf::detail::row_ir::opcode::PREDICATE;
+    case 10: return cudf::detail::row_ir::opcode::ANSI_PRECISION_CHECK;
+    case 11: return cudf::detail::row_ir::opcode::ANSI_TRY_PRECISION_CHECK;
+    case 12: return cudf::detail::row_ir::opcode::CAST_TO_DEC32;
+    case 13: return cudf::detail::row_ir::opcode::CAST_TO_DEC64;
+    case 14: return cudf::detail::row_ir::opcode::CAST_TO_DEC128;
+    case 15: return cudf::detail::row_ir::opcode::RESCALE;
     default: throw std::invalid_argument("unexpected JNI AST JIT operator value");
   }
 }
@@ -380,13 +387,21 @@ cudf::ast::expression& compile_jit_expression(cudf::jni::ast::compiled_expr& com
   auto const opcode = jni_to_jit_operator(jni_ast.read_byte());
   auto const arity  = static_cast<int32_t>(jni_ast.read_byte());
   if (arity < 0) { throw std::invalid_argument("unexpected JNI AST JIT operator arity"); }
+  auto const has_target_scale = jni_ast.read_byte();
+  std::optional<int32_t> target_scale;
+  if (has_target_scale != 0) { target_scale = jni_ast.read<int32_t>(); }
   std::vector<std::reference_wrapper<cudf::ast::expression const>> args;
   args.reserve(arity);
   for (int32_t index = 0; index < arity; ++index) {
     args.emplace_back(compile_expression(compiled_expr, jni_ast));
   }
-  return compiled_expr.add_expression(
-    std::make_unique<cudf::ast::jit::detail::operation>(opcode, std::move(args)));
+  if (target_scale.has_value()) {
+    return compiled_expr.add_expression(std::make_unique<cudf::ast::jit::detail::operation>(
+      opcode, std::move(args), target_scale.value()));
+  } else {
+    return compiled_expr.add_expression(
+      std::make_unique<cudf::ast::jit::detail::operation>(opcode, std::move(args)));
+  }
 }
 
 /** Decode a serialized AST expression by reading the expression type and dispatching */

--- a/java/src/test/java/ai/rapids/cudf/ast/CompiledExpressionTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ast/CompiledExpressionTest.java
@@ -395,7 +395,26 @@ public class CompiledExpressionTest extends CudfTestBase {
           new ColumnReference(2));
       try (CompiledExpression compiledExpr = expr.compile();
            ColumnVector actual = compiledExpr.computeColumn(t);
-           ColumnVector expected = ColumnVector.fromBoxedInts(1, 20, null, null, null)) {
+           ColumnVector expected = ColumnVector.fromBoxedInts(1, 20, 3, null, null)) {
+        assertColumnsAreEqual(expected, actual);
+      }
+    }
+  }
+
+  @Test
+  void testJitIfElsePredicateTransform() {
+    try (Table t = new Table.TestBuilder()
+        .column(1, 2, 3, null, 5)
+        .column(10, 20, null, 40, 50)
+        .column(true, false, true, true, null)
+        .build()) {
+      JitOperation expr = new JitOperation(JitOperator.IF_ELSE,
+          new ColumnReference(0),
+          new ColumnReference(1),
+          new JitOperation(JitOperator.PREDICATE, new ColumnReference(2)));
+      try (CompiledExpression compiledExpr = expr.compile();
+           ColumnVector actual = compiledExpr.computeColumn(t);
+           ColumnVector expected = ColumnVector.fromBoxedInts(1, 20, 3, null, 50)) {
         assertColumnsAreEqual(expected, actual);
       }
     }

--- a/java/src/test/java/ai/rapids/cudf/ast/CompiledExpressionTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ast/CompiledExpressionTest.java
@@ -312,6 +312,95 @@ public class CompiledExpressionTest extends CudfTestBase {
     return result;
   }
 
+  @Test
+  void testJitOperationArityValidation() {
+    AstExpression[] inputs = new AstExpression[] {
+        new ColumnReference(0),
+        new ColumnReference(1),
+        new ColumnReference(2)
+    };
+    for (JitOperator op : JitOperator.values()) {
+      Assertions.assertDoesNotThrow(
+          () -> new JitOperation(op, Arrays.copyOf(inputs, op.getArity())));
+      if (op.getArity() > 0) {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new JitOperation(op, Arrays.copyOf(inputs, op.getArity() - 1)));
+      }
+    }
+  }
+
+  @Test
+  void testJitTryDivModTransform() {
+    try (Table t = new Table.TestBuilder()
+        .column(10, 7, null, 6)
+        .column(2, 0, 3, null)
+        .build()) {
+      JitOperation divExpr = new JitOperation(JitOperator.ANSI_TRY_DIV,
+          new ColumnReference(0),
+          new ColumnReference(1));
+      try (CompiledExpression compiledExpr = divExpr.compile();
+           ColumnVector actual = compiledExpr.computeColumn(t);
+           ColumnVector expected = ColumnVector.fromBoxedInts(5, null, null, null)) {
+        assertColumnsAreEqual(expected, actual);
+      }
+
+      JitOperation modExpr = new JitOperation(JitOperator.ANSI_TRY_MOD,
+          new ColumnReference(0),
+          new ColumnReference(1));
+      try (CompiledExpression compiledExpr = modExpr.compile();
+           ColumnVector actual = compiledExpr.computeColumn(t);
+           ColumnVector expected = ColumnVector.fromBoxedInts(0, null, null, null)) {
+        assertColumnsAreEqual(expected, actual);
+      }
+    }
+  }
+
+  @Test
+  void testJitPrimitiveCastTransform() {
+    try (Table t = new Table.TestBuilder().column(1, -2, null, 3).build()) {
+      JitOperation castToInt = new JitOperation(JitOperator.CAST_TO_I32, new ColumnReference(0));
+      try (CompiledExpression compiledExpr = castToInt.compile();
+           ColumnVector actual = compiledExpr.computeColumn(t);
+           ColumnVector expected = ColumnVector.fromBoxedInts(1, -2, null, 3)) {
+        assertColumnsAreEqual(expected, actual);
+      }
+
+      JitOperation castToLong = new JitOperation(JitOperator.CAST_TO_I64, new ColumnReference(0));
+      try (CompiledExpression compiledExpr = castToLong.compile();
+           ColumnVector actual = compiledExpr.computeColumn(t);
+           ColumnVector expected = ColumnVector.fromBoxedLongs(1L, -2L, null, 3L)) {
+        assertColumnsAreEqual(expected, actual);
+      }
+
+      JitOperation castToDouble = new JitOperation(JitOperator.CAST_TO_F64, new ColumnReference(0));
+      try (CompiledExpression compiledExpr = castToDouble.compile();
+           ColumnVector actual = compiledExpr.computeColumn(t);
+           ColumnVector expected = ColumnVector.fromBoxedDoubles(1.0, -2.0, null, 3.0)) {
+        assertColumnsAreEqual(expected, actual);
+      }
+    }
+  }
+
+  @Test
+  void testJitIfElseTransform() {
+    try (Table t = new Table.TestBuilder()
+        .column(1, 2, 3, 4)
+        .column(10, 20, 30, 40)
+        .column(true, false, true, false)
+        .build()) {
+      JitOperation expr = new JitOperation(JitOperator.IF_ELSE,
+          new ColumnReference(0),
+          new ColumnReference(1),
+          new ColumnReference(2));
+      try (CompiledExpression compiledExpr = expr.compile();
+           ColumnVector actual = compiledExpr.computeColumn(t);
+           ColumnVector expected = ColumnVector.fromBoxedInts(1, 20, 3, 40)) {
+        assertColumnsAreEqual(expected, actual);
+      }
+    }
+  }
+
   private static Stream<Arguments> createUnaryDoubleOperationParams() {
     Double[] input = new Double[] { -5., 4.5, null, 2.7, 1.5 };
     return Stream.of(

--- a/java/src/test/java/ai/rapids/cudf/ast/CompiledExpressionTest.java
+++ b/java/src/test/java/ai/rapids/cudf/ast/CompiledExpressionTest.java
@@ -385,9 +385,9 @@ public class CompiledExpressionTest extends CudfTestBase {
   @Test
   void testJitIfElseTransform() {
     try (Table t = new Table.TestBuilder()
-        .column(1, 2, 3, 4)
-        .column(10, 20, 30, 40)
-        .column(true, false, true, false)
+        .column(1, 2, 3, null, 5)
+        .column(10, 20, null, 40, 50)
+        .column(true, false, true, true, null)
         .build()) {
       JitOperation expr = new JitOperation(JitOperator.IF_ELSE,
           new ColumnReference(0),
@@ -395,7 +395,7 @@ public class CompiledExpressionTest extends CudfTestBase {
           new ColumnReference(2));
       try (CompiledExpression compiledExpr = expr.compile();
            ColumnVector actual = compiledExpr.computeColumn(t);
-           ColumnVector expected = ColumnVector.fromBoxedInts(1, 20, 3, 40)) {
+           ColumnVector expected = ColumnVector.fromBoxedInts(1, 20, null, null, null)) {
         assertColumnsAreEqual(expected, actual);
       }
     }


### PR DESCRIPTION
## Summary

This is a review-only stacked PR on top of `codex-ansi-jit-on-current`.

It collects local follow-up changes found while validating ANSI row IR support from rapidsai/cudf#22224 with spark-rapids:

- expose additional row IR operators through Java/JNI
- add decimal JIT AST binding helpers
- fix ANSI modulo semantics and transform error handling
- fix nullable JIT `IF_ELSE` implementation issues
- recover from corrupt JIT kernel cache entries when Jitify deserialization fails

## Notes

This PR is not intended to include the upstream/main merge diff. The base branch already contains that context, so the review diff should only show the follow-up commits in this branch.

Some items here may be better split or discussed upstream before merging, especially where Spark semantics and cuDF operator semantics differ.

## Testing

Not run in this PR creation step.